### PR TITLE
Fixed Downlink Frequency Typo

### DIFF
--- a/srslte_user_manuals/source/srsenb/source/2_enb_getstarted.rst
+++ b/srslte_user_manuals/source/srsenb/source/2_enb_getstarted.rst
@@ -76,7 +76,7 @@ A key eNodeB parameter is enb.mme_addr, which specifies the IP address of the co
 Hardware Setup
 **************
 
-To use srsENB to create an over-the-air local cell, you will need an RF front-end and suitable antennas. The default EARFCN is 3400 (2565MHz uplink, 2865MHz downlink). To reduce TX-RX crosstalk, we recommend orienting TX and RX antennas at a 90 degree angle to each other.
+To use srsENB to create an over-the-air local cell, you will need an RF front-end and suitable antennas. The default EARFCN is 3400 (2565MHz uplink, 2685MHz downlink). To reduce TX-RX crosstalk, we recommend orienting TX and RX antennas at a 90 degree angle to each other.
 
 The srsENB can also be used over a cabled connection. The cable configuration and required RF components will depend upon your RF front-end. For RF front-ends such as the USRP, connect TX to RX and ensure at least 30dB of attenuation to avoid damage to your devices. For more detailed information about cabled connections, see :doc:`Advanced Usage <4_enb_advanced>`.
 

--- a/srslte_user_manuals/source/srsue/source/2_ue_getstarted.rst
+++ b/srslte_user_manuals/source/srsue/source/2_ue_getstarted.rst
@@ -81,7 +81,7 @@ To connect successfully to a network, these parameters will need to match those 
 Hardware Setup
 **************
 
-To use srsUE to connect over-the-air to a local network, you will need an RF front-end and suitable antennas. The default EARFCN is 3400 (2565MHz uplink, 2865MHz downlink). To reduce TX-RX crosstalk, we recommend orienting TX and RX antennas at a 90 degree angle to each other.
+To use srsUE to connect over-the-air to a local network, you will need an RF front-end and suitable antennas. The default EARFCN is 3400 (2565MHz uplink, 2685MHz downlink). To reduce TX-RX crosstalk, we recommend orienting TX and RX antennas at a 90 degree angle to each other.
 
 The srsUE can also be used over a cabled connection. The cable configuration and required RF components will depend upon your RF front-end. For RF front-ends such as the USRP, connect TX to RX and ensure at least 30dB of attenuation to avoid damage to your devices. For more detailed information about cabled connections, see :doc:`Advanced Usage <4_ue_advanced>`.
 


### PR DESCRIPTION
The downlink frequencies listed in the Getting Started Documentation for eNB and UE had a small typo. The frequencies were changed to the appropriate values which can be confirmed at the following link (https://www.cellmapper.net/arfcn?net=LTE&ARFCN=3400&MCC=0).