### PR TITLE
Use the same IMSI as in the attached ue.conf

### DIFF
--- a/srsran_user_manuals/source/app_notes/source/5g_sa_E2E/source/index.rst
+++ b/srsran_user_manuals/source/app_notes/source/5g_sa_E2E/source/index.rst
@@ -107,7 +107,7 @@ The following USIM Credentials are used::
     algo = milenage
     opc  = 63BFA50EE6523365FF14C1F45F88737D
     k    = 00112233445566778899aabbccddeeff
-    imsi = 901700123456789
+    imsi = 901700123456780
     imei = 353490069873319
 
 The main change here is adjusting the IMSI, so that the correct PLMN is used. 


### PR DESCRIPTION
The ue.conf attached to this document does not contain the IMSI in the USIM Credentials & APN section of the document.
Make sure they are the same, so the subscriber is known when the UE tries to connect.