### PR TITLE
set relase to 10 to activate SCELL

### DIFF
--- a/srsran_user_manuals/source/app_notes/source/2ca/source/index.rst
+++ b/srsran_user_manuals/source/app_notes/source/2ca/source/index.rst
@@ -59,7 +59,7 @@ The second step is to configure srsENB with two cells. For this, one needs to mo
       cell_id = 0x02;
       tac = 0x0007;
       pci = 4;
-      root_seq_idx = 205;
+      root_seq_idx = 268;
       dl_earfcn = 3050;
 
       // CA cells
@@ -99,6 +99,7 @@ For the UE capabilities, we need to report at least release
   [rrc]
   ue_category        = 7
   ue_category_dl     = 10
+  release            = 10
 
 With these changes, simply run srsUE as usual.
 


### PR DESCRIPTION
Hi @brendan-mcauliffe, 

I am testing CA now and found two issues. First, the secondary cell is not activated without setting the release to 10. Second, it is good to set root_seq_idx = 268 in SCell to ensure both cells have orthogonal preambles. 

Best,
Piotr