### PR TITLE
Added additional instruction to 1_installation.rst: run sudo ldconfig

### DIFF
--- a/docs/source/general/source/1_installation.rst
+++ b/docs/source/general/source/1_installation.rst
@@ -109,6 +109,7 @@ Install srsRAN 4G::
 
   sudo make install
   srsran_install_configs.sh user
+  sudo ldconfig
 
 This installs srsRAN 4G and also copies the default srsRAN 4G config files to *~/.config/srsran*.
 


### PR DESCRIPTION
I added the instruction to run ```sudo ldconfig``` after installing srsRAN_4G from source.

On Ubuntu Desktop 22.04 LTS, not running ```sudo ldconfig``` will cause errors when executing srsue and srsenb:

```
$ sudo srsue
srsue: error while loading shared libraries: libsrsran_rf.so.0: cannot open shared object file: No such file or directory

$ sudo srsenb
srsenb: error while loading shared libraries: libsrsran_rf.so.0: cannot open shared object file: No such file or directory
```